### PR TITLE
Redirect stdout and stderr to null

### DIFF
--- a/SOURCES/xcp-rrdd-gpumon.service
+++ b/SOURCES/xcp-rrdd-gpumon.service
@@ -8,8 +8,8 @@ Wants=syslog.target
 Environment=OCAMLRUNPARAM=b
 ExecStart=/opt/xensource/libexec/xcp-rrdd-plugins/xcp-rrdd-gpumon
 SuccessExitStatus=0
-# StandardOutput=null
-# StandardError=null
+StandardOutput=null
+StandardError=null
 # restart but fail if more than 25 failures in 30s
 Restart=on-failure
 StartLimitBurst=25

--- a/SPECS/gpumon.spec
+++ b/SPECS/gpumon.spec
@@ -2,7 +2,7 @@
 %global package_srccommit v0.25.0
 Name:           gpumon
 Version: 0.25.0
-Release: 1.1%{?xsrel}%{?dist}
+Release: 1.2%{?xsrel}%{?dist}
 Summary:        RRDD GPU metrics plugin
 Group:          System/Hypervisor
 License:        ISC
@@ -49,6 +49,9 @@ DESTDIR=%{buildroot} %{__make} install
 %{_unitdir}/xcp-rrdd-gpumon.service
 
 %changelog
+* Fri Nov 03 2023 Guillaume Thouvenin <guillaume.thouvenin@vates.tech> - 0.25.0-1.2
+- Don't output to stdout/stderr (and thus daemon.log): there already are RRDD logs
+
 * Wed Sep 27 2023 Samuel Verschelde <stormi-xcp@ylix.fr> - 0.25.0-1.1
 - Update to 0.25.0-1
 - *** Upstream changelog ***


### PR DESCRIPTION
In the Ocaml RRDD library when the plugin initializes the output is redirected into Syslog.Local0 that is xcp-rrdd-plugin.log. Thus we don't need to also get them into daemon.log.